### PR TITLE
Added support for newer EAP225 Versions using Firmware version >= 5.2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+ha-config/*
+*.pyc

--- a/README.md
+++ b/README.md
@@ -16,11 +16,15 @@ Then, in configuration.yaml, add the following:
 ```
 eap225:
   # host is the ip of the EAP225 access point
-  host: 192.168.3.4
+  host: <<a.b.c.d>>
   # then you need to provide username and password to log into it (the same credentials you used in the web interface)
-  username: abcdefg
-  password: hijklm
+  username: <<example_username>>
+  password: <<example_password>>
+  cli_omada: true
+  scan_interval: 15 //Min accepted interval is 15
 ```
+
+The EAP 225 Series is shipped with different versions. Starting with EAP225 V4 - Firmware Version 5.2 the cli received a major update which is not compatible with the old ssh commands. If you have the new cli version please set "cli_omada: true" else "cli_omada: false"
 
 Then, in your binary sensors (either the binary_sensors: section of configuration.yaml or your binary_sensors.yaml file)
 ```

--- a/custom_components/eap225/__init__.py
+++ b/custom_components/eap225/__init__.py
@@ -1,9 +1,10 @@
 """The example sensor integration."""
 import logging
-import paramiko,re
-
+import re
 from datetime import timedelta
 from datetime import datetime
+
+import paramiko
 
 DOMAIN = "eap225"
 SCAN_INTERVAL = timedelta(seconds=2)
@@ -11,6 +12,7 @@ SCAN_INTERVAL = timedelta(seconds=2)
 _LOGGER = logging.getLogger(__name__)
 
 def setup(hass, config):
+
     _LOGGER.debug("starting")
     
     api = EAP225Client(config)

--- a/custom_components/eap225/__init__.py
+++ b/custom_components/eap225/__init__.py
@@ -7,7 +7,10 @@ from datetime import datetime
 import paramiko
 
 DOMAIN = "eap225"
-SCAN_INTERVAL = timedelta(seconds=2)
+#In respect to the homeassistant appropiate polling policy the minimal polling frequency is limited by the component to 10 seconds.
+#Each value under 15 seconds will default to 15
+#Reference: https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/appropriate-polling/
+MIN_APPROPIATE_SCAN_INTERVAL = 15
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,6 +35,37 @@ class EAP225Client():
     self.host = config[DOMAIN].get("host")
     self.username = config[DOMAIN].get("username")
     self.password = config[DOMAIN].get("password")
+    #Check if the new or old cli should be used - default: Old CLI
+    self.cli_omada = config[DOMAIN].get("cli_omada", False)
+
+    #Validate scan interval - see explanaition above at MIN_APPROPIATE_SCAN_INTERVAL
+    try:
+      validated_scan_interval = int(config[DOMAIN].get("scan_interval", 30))
+      if (validated_scan_interval < MIN_APPROPIATE_SCAN_INTERVAL):
+        validated_scan_interval = MIN_APPROPIATE_SCAN_INTERVAL
+
+      self.scan_interval = timedelta(seconds=validated_scan_interval)
+    except Exception as e:
+      _LOGGER.warning("COnfigured scan interval is not valid - default value is used! - Error: " + str(e))
+      self.scan_interval = timedelta(seconds=validated_scan_interval)
+
+
+    _LOGGER.info(
+    "EAP225 Integration - Using "
+    + ("New CLI" if self.cli_omada else "Old CLI")
+    + " mode - Scan Interval: "
+    + str(self.scan_interval)
+    + " Using host "
+    + self.username + "@" + self.host
+)
+
+  def normalize_mac(self, mac):
+    if mac is None:
+      return ""
+    normalized_mac = re.sub(r"[^0-9a-fA-F]", "", str(mac)).lower()
+    if len(normalized_mac) != 12:
+      return ""
+    return normalized_mac
 
   def get_macs(self):
     self.updateIfNeeded()
@@ -39,35 +73,62 @@ class EAP225Client():
 
   def validate_mac(self,mac):
     self.updateIfNeeded()
+    normalized_mac = self.normalize_mac(mac)
     for m in self.macs:
-      if mac == m: return True
+      if normalized_mac == self.normalize_mac(m): return True
     return False
 
   def update(self):
   
-    #_LOGGER.warning("updating")
+    _LOGGER.debug("updating")
   
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    ssh.connect(self.host, username=self.username, password=self.password)
-    
-    stdin, stdout, stderr = ssh.exec_command("iwconfig")
-    interfaces = re.findall("ath[0-9]+",str(stdout.read()))
-    
-    txt = ""
-    for int in interfaces:
-      cmd = f"wlanconfig {int} list"
-
-      stdin, stdout, stderr = ssh.exec_command(cmd)
-      txt = txt + str(stdout.read())
-    ssh.close()
-    
-    txt = re.finditer("([0-9a-z]{2}[:-]){5}[0-9a-z]{2}",txt,flags=0)
-
     self.macs = []
-    for hex in txt:
-      self.macs.append(hex.group())
+
+    if(not self.cli_omada):
+      #Establish SSH connection in this block to prevent disrupting already configured setups with the new ssh connection configuration
+      ssh.connect(self.host, username=self.username, password=self.password)
+
+      _LOGGER.debug("Use old CLI Version (pre v5.2)")
+      stdin, stdout, stderr = ssh.exec_command("iwconfig")
+      interfaces = re.findall("ath[0-9]+",str(stdout.read()))
+
+      txt = ""
+      for int in interfaces:
+        cmd = f"wlanconfig {int} list"
+
+        stdin, stdout, stderr = ssh.exec_command(cmd)
+        txt = txt + str(stdout.read())
+      ssh.close()
+
+      txt = re.finditer("([0-9a-z]{2}[:-]){5}[0-9a-z]{2}",txt,flags=0)
       
+      for hex in txt:
+        self.macs.append(hex.group())
+
+    else:
+      _LOGGER.debug("Updating via new Omada CLI")
+      ssh.connect(hostname=self.host, username=self.username, password=self.password, allow_agent=False, look_for_keys=False)
+
+      # Create a new shell
+      chan = ssh.invoke_shell()
+      chan.settimeout(5)
+      #Wait for the interactive shell
+      self.read_until(chan, (">", "#"))
+      #Enable privileged mode (normally no password needed)
+      enable_output = self.send_and_read(chan, "enable", ("#", "Password:"))
+      #Fetch all conntected hosts
+      station_info = self.send_and_read(chan, "show station info", ("#",))
+
+      chan.close()
+      ssh.close()
+
+      station_info_macs = re.findall(r"(?:[0-9a-fA-F]{2}[:-]){5}[0-9a-fA-F]{2}", station_info, flags=0)
+      
+      for mac in station_info_macs:
+        self.macs.append(mac)
+
     if self.macs:
       self.lastUpdate = datetime.now()
       return True
@@ -75,4 +136,16 @@ class EAP225Client():
       return False
 
   def updateIfNeeded(self):
-    if self.lastUpdate + SCAN_INTERVAL < datetime.now(): self.update()
+    if self.lastUpdate + self.scan_interval < datetime.now(): self.update()
+
+  #Additions for Omada CLI to use the interactive shell
+  def read_until(self, channel, markers):
+    output = ""
+    while not output.rstrip().endswith(markers):
+        output += channel.recv(65535).decode("utf-8", errors="replace")
+    return output
+
+
+  def send_and_read(self, channel, command, markers):
+    channel.send(command + "\n")
+    return self.read_until(channel, markers)

--- a/custom_components/eap225/binary_sensor.py
+++ b/custom_components/eap225/binary_sensor.py
@@ -3,13 +3,14 @@ import logging
 from homeassistant.helpers.entity import Entity
 from . import DOMAIN
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from datetime import timedelta
 
+SCAN_INTERVAL = timedelta(seconds=15)
 _LOGGER = logging.getLogger(__name__)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
   sensor = eap225Sensor(hass,config)
   add_devices([sensor])
-
 
 class eap225Sensor(Entity):
   
@@ -18,7 +19,7 @@ class eap225Sensor(Entity):
     self._name = config.get("name")
     self.api = hass.data[DOMAIN]
     self.update()
-  
+    
   @property
   def is_on(self):
     """Return true if the binary sensor is on."""

--- a/custom_components/eap225/manifest.json
+++ b/custom_components/eap225/manifest.json
@@ -5,5 +5,7 @@
   "dependencies": [],
   "codeowners": ["roger1233", "j54j6"],
   "requirements": ["paramiko"],
-  "version": "1.1.2"
+  "version": "1.1.2",
+  "zeroconf": [],
+  "config_flow": true
 }

--- a/custom_components/eap225/manifest.json
+++ b/custom_components/eap225/manifest.json
@@ -5,7 +5,5 @@
   "dependencies": [],
   "codeowners": ["roger1233", "j54j6"],
   "requirements": ["paramiko"],
-  "version": "1.1.2",
-  "zeroconf": [],
-  "config_flow": true
+  "version": "1.1.2"
 }

--- a/custom_components/eap225/manifest.json
+++ b/custom_components/eap225/manifest.json
@@ -5,5 +5,5 @@
   "dependencies": [],
   "codeowners": ["roger1233", "j54j6"],
   "requirements": ["paramiko"],
-  "version": "1.1.1"
+  "version": "1.1.2"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,5 @@
   "name": "TPLink EAP225 presence detector by MAC address",
   "content_in_root": false,
   "iot_class": ["Local Polling"],
-  "homeassistant": "2022.1.0",
+  "homeassistant": "2022.1.0"
 }


### PR DESCRIPTION
Add support for newer TP-Link EAP225 firmware versions (5.2.2+)

This update adds compatibility with newer EAP225 devices running firmware version 5.2.2 or later, which use a different SSH/CLI interface than older releases.

Changes:
- Added support for the newer Omada CLI mode used by recent firmware versions
- Kept compatibility with older EAP225 firmware versions
- Improved MAC address handling and client detection across CLI variants
- Added configuration options to better control integration behavior
